### PR TITLE
Fix of esbench.sh for Ubuntu

### DIFF
--- a/distribution/src/main/resources/bin/esbench.sh
+++ b/distribution/src/main/resources/bin/esbench.sh
@@ -13,4 +13,4 @@ else
     JAVA=`which java`
 fi
 
-exec "$JAVA" -cp $BENCH_CLASSPATH "org.esbench.cmd.EsBenchCommandLine" "$@"
+exec "$JAVA" -cp "$BENCH_CLASSPATH" "org.esbench.cmd.EsBenchCommandLine" "$@"


### PR DESCRIPTION
Fix - didn't work on ubuntu without quots
